### PR TITLE
Add Home page and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,21 @@ Sitio de pruebas basado en Vite y React.
 - `npm run test` &mdash; ejecuta las pruebas con Vitest.
 
 Antes de ejecutar los scripts es necesario instalar las dependencias con `npm install`.
+
+## Crear nuevas páginas
+
+Las vistas del proyecto se agrupan en la carpeta `src/pages`. Cada página
+debe ubicarse en un directorio propio para mantener los componentes y estilos
+aislados. Por ejemplo, la página de inicio se encuentra en
+`src/pages/Home` y su componente principal es `Home.tsx`.
+
+Para añadir una nueva página:
+
+1. Crea un directorio dentro de `src/pages` con el nombre de la página.
+2. Dentro de esa carpeta agrega el archivo `Nombre.tsx` que contendrá el
+   componente de la página.
+3. Si la vista necesita componentes adicionales, colócalos en `src/components`.
+4. Importa la página desde `src/App.tsx` o configura las rutas con React Router.
+
+Este esquema mantiene una separación clara entre páginas y componentes
+reutilizables, siguiendo buenas prácticas de React.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import Home from './pages/Home/Home';
 
 function App() {
-  return <h1>Hola Mundo</h1>;
+  return <Home />;
 }
 
 export default App;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Header: React.FC = () => {
+  return (
+    <header style={{ backgroundColor: '#1976d2', color: '#fff', padding: '1rem' }}>
+      <h1>Webportal</h1>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/components/NotificationsCarousel.tsx
+++ b/src/components/NotificationsCarousel.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Carousel } from 'react-responsive-carousel';
+import 'react-responsive-carousel/lib/styles/carousel.min.css';
+
+const NotificationsCarousel: React.FC = () => {
+  const items = [
+    'Bienvenido al portal!',
+    'No olvides revisar las novedades.',
+    'Actualiza tu perfil para recibir más notificaciones.',
+  ];
+
+  return (
+    <Carousel
+      autoPlay
+      infiniteLoop
+      showThumbs={false}
+      showStatus={false}
+      interval={5000}
+    >
+      {items.map((text, index) => (
+        <div key={index}>
+          <p>{text}</p>
+        </div>
+      ))}
+    </Carousel>
+  );
+};
+
+export default NotificationsCarousel;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const Sidebar: React.FC = () => {
+  return (
+    <aside
+      style={{
+        width: '200px',
+        backgroundColor: '#f5f5f5',
+        padding: '1rem',
+        borderRight: '1px solid #ddd',
+        height: '100vh',
+        boxSizing: 'border-box',
+      }}
+    >
+      <nav>
+        <ul style={{ listStyle: 'none', padding: 0 }}>
+          <li>Inicio</li>
+          <li>Perfil</li>
+          <li>Configuración</li>
+        </ul>
+      </nav>
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Header from '../../components/Header';
+import Sidebar from '../../components/Sidebar';
+import NotificationsCarousel from '../../components/NotificationsCarousel';
+
+const Home: React.FC = () => {
+  return (
+    <div style={{ display: 'flex' }}>
+      <Sidebar />
+      <div style={{ flex: 1 }}>
+        <Header />
+        <div style={{ padding: '1rem' }}>
+          <NotificationsCarousel />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
## Summary
- create a Home page with header, sidebar and carousel
- add reusable components for layout
- update README with instructions on how to create new pages

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686956ea12288330a10cc58d5f807eef