### PR TITLE
Implement responsive layout

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,11 +2,24 @@ import React from 'react';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
 
-const Header: React.FC = () => {
+interface HeaderProps {
+  onMenuClick: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
   return (
     <AppBar position="static">
       <Toolbar>
+        <IconButton
+          color="inherit"
+          edge="start"
+          onClick={onMenuClick}
+          sx={{ mr: 2, display: { sm: 'none' } }}
+        >
+          <span className="material-icons">menu</span>
+        </IconButton>
         <Typography variant="h6" component="div">
           Webportal
         </Typography>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,27 +5,58 @@ import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import Toolbar from '@mui/material/Toolbar';
 
+interface SidebarProps {
+  mobileOpen: boolean;
+  onClose: () => void;
+}
+
 const drawerWidth = 240;
 
-const Sidebar: React.FC = () => {
+const Sidebar: React.FC<SidebarProps> = ({ mobileOpen, onClose }) => {
   return (
-    <Drawer
-      variant="permanent"
-      sx={{
-        width: drawerWidth,
-        flexShrink: 0,
-        [`& .MuiDrawer-paper`]: { width: drawerWidth, boxSizing: 'border-box' },
-      }}
-    >
-      <Toolbar />
-      <List>
-        {['Inicio', 'Perfil', 'Configuración'].map((text) => (
-          <ListItem button key={text}>
-            <ListItemText primary={text} />
-          </ListItem>
-        ))}
-      </List>
-    </Drawer>
+    <>
+      <Drawer
+        variant="temporary"
+        open={mobileOpen}
+        onClose={onClose}
+        ModalProps={{ keepMounted: true }}
+        sx={{
+          display: { xs: 'block', sm: 'none' },
+          [`& .MuiDrawer-paper`]: {
+            width: drawerWidth,
+            boxSizing: 'border-box',
+          },
+        }}
+      >
+        <Toolbar />
+        <List>
+          {['Inicio', 'Perfil', 'Configuración'].map((text) => (
+            <ListItem button key={text}>
+              <ListItemText primary={text} />
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+      <Drawer
+        variant="permanent"
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          display: { xs: 'none', sm: 'block' },
+          [`& .MuiDrawer-paper`]: { width: drawerWidth, boxSizing: 'border-box' },
+        }}
+        open
+      >
+        <Toolbar />
+        <List>
+          {['Inicio', 'Perfil', 'Configuración'].map((text) => (
+            <ListItem button key={text}>
+              <ListItemText primary={text} />
+            </ListItem>
+          ))}
+        </List>
+      </Drawer>
+    </>
   );
 };
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,15 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Box from '@mui/material/Box';
 import Header from '../../components/Header';
 import Sidebar from '../../components/Sidebar';
 import NotificationsCarousel from '../../components/NotificationsCarousel';
 
 const Home: React.FC = () => {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen((prev) => !prev);
+  };
+
   return (
     <Box sx={{ display: 'flex' }}>
-      <Sidebar />
+      <Sidebar mobileOpen={mobileOpen} onClose={handleDrawerToggle} />
       <Box component="main" sx={{ flexGrow: 1 }}>
-        <Header />
+        <Header onMenuClick={handleDrawerToggle} />
         <Box sx={{ p: 2 }}>
           <NotificationsCarousel />
         </Box>


### PR DESCRIPTION
## Summary
- add mobile menu button to header
- make sidebar responsive with temporary drawer on small screens
- connect sidebar toggle to home page

## Testing
- `npm run check-types` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696b52204c8330a5007ab91f0ddf9b